### PR TITLE
add null safety check to setAddressAsString in MacAddress.

### DIFF
--- a/base-models/src/main/java/com/telecominfraproject/wlan/core/model/equipment/MacAddress.java
+++ b/base-models/src/main/java/com/telecominfraproject/wlan/core/model/equipment/MacAddress.java
@@ -163,6 +163,10 @@ public class MacAddress extends BaseJsonModel implements Comparable<MacAddress>
 
     
     private static byte[] stringToByteArray(String str) {
+        if (str == null)
+        {
+            return null;
+        }
         byte[] ret = new byte[6];
 
         String octets[] = str.split(":");


### PR DESCRIPTION
if the macAddress string is null we were causing a NPE when jackson uses the setAddressAsString method.