### PR TITLE
[WIFI-3022] fix for getting 00:00:00:00:00:00 mac address

### DIFF
--- a/base-models/src/main/java/com/telecominfraproject/wlan/core/model/equipment/MacAddress.java
+++ b/base-models/src/main/java/com/telecominfraproject/wlan/core/model/equipment/MacAddress.java
@@ -301,7 +301,7 @@ public class MacAddress extends BaseJsonModel implements Comparable<MacAddress>
         
         byte[] bval = stringToByteArray(macStr);
 
-        if (bval.length >= 6) {
+        if (bval != null && bval.length >= 6) {
             long mac = 0;
             for (var i = 0; i < 6; i++) {
                 long t = (bval[i] & 0xffL) << ((5 - i) * 8);

--- a/base-models/src/main/java/com/telecominfraproject/wlan/core/model/equipment/MacAddress.java
+++ b/base-models/src/main/java/com/telecominfraproject/wlan/core/model/equipment/MacAddress.java
@@ -82,9 +82,10 @@ public class MacAddress extends BaseJsonModel implements Comparable<MacAddress>
             }
 
             sb.setLength(sb.length() - 1);
+            return sb.toString();
         }
         
-        return sb.toString();
+        return null;
     }
 
     @JsonIgnore
@@ -163,7 +164,7 @@ public class MacAddress extends BaseJsonModel implements Comparable<MacAddress>
 
     
     private static byte[] stringToByteArray(String str) {
-        if (str == null)
+        if (str == null || str.equals(""))
         {
             return null;
         }


### PR DESCRIPTION
When we do an equipment update while the baseMacAddress is null, we will receive an empty string instead of null and eventually will get converted to 00:00:00:00:00:00. This PR fixes the issue.